### PR TITLE
Ensure unapproved users aren't member of groups, fail if details of a user are left unprocessed and deal with the fallout. Plus fixes.

### DIFF
--- a/fas2ipa/groups.py
+++ b/fas2ipa/groups.py
@@ -104,7 +104,7 @@ class Groups(ObjectManager):
                 except python_freeipa.exceptions.FreeIPAError as e:
                     if e.message != "no modifications to be performed":
                         raise
-                return Status.UPDATED
+                return Status.UNMODIFIED
             else:
                 print(e.message)
                 print(e)

--- a/fas2ipa/status.py
+++ b/fas2ipa/status.py
@@ -9,6 +9,7 @@ class Status(Enum):
     FAILED = "FAILED"
     SKIPPED = "SKIPPED"
     UNMODIFIED = "UNMODIFIED"
+    REMOVED = "REMOVED"
 
 
 def print_status(status, text=None):
@@ -22,6 +23,8 @@ def print_status(status, text=None):
         color = Style.BRIGHT + Fore.BLUE
     elif status == Status.UNMODIFIED:
         color = Style.BRIGHT + Fore.YELLOW
+    elif status == Status.REMOVED:
+        color = Style.NORMAL + Fore.MAGENTA
     else:
         raise ValueError(f"Unknown status: {status!r}")
     print(f"{color}{text or status.value}{Style.RESET_ALL}")

--- a/fas2ipa/users.py
+++ b/fas2ipa/users.py
@@ -33,7 +33,7 @@ class Users(ObjectManager):
                 start_index = alphabet.index(users_start_at[0].lower())
                 user_patterns = [
                     pattern + "*"
-                    for pattern in [users_start_at] + alphabet[: start_index + 1]
+                    for pattern in [users_start_at] + alphabet[start_index + 1 :]
                 ]
             else:
                 user_patterns = [pattern + "*" for pattern in alphabet]

--- a/fas2ipa/users.py
+++ b/fas2ipa/users.py
@@ -253,7 +253,7 @@ class Users(ObjectManager):
                         if added:
                             print_status(
                                 Status.ADDED,
-                                f"Added {category} to {group}: {', '.join(sorted(list(added)))}",
+                                f"Added {category} to {group}: {', '.join(sorted(added))}",
                             )
                     finally:
                         bar.update(counter)

--- a/fas2ipa/users.py
+++ b/fas2ipa/users.py
@@ -35,6 +35,8 @@ class Users(ObjectManager):
                     pattern + "*"
                     for pattern in [users_start_at] + alphabet[: start_index + 1]
                 ]
+            else:
+                user_patterns = [pattern + "*" for pattern in alphabet]
 
         stats = Stats()
 

--- a/fas2ipa/users.py
+++ b/fas2ipa/users.py
@@ -172,12 +172,39 @@ class Users(ObjectManager):
 
         # Don't modify the original object, and remove all key/value pairs that should
         # be ignored
+        ignored_keys = {
+            "affiliation",
+            "alias_enabled",
+            "certificate_serial",
+            "comments",
+            "country_code",
+            "facsimile",
+            "group_roles",
+            "id",
+            "internal_comments",
+            "ipa_sync_status",
+            "last_seen",
+            "latitude",
+            "longitude",
+            "memberships",
+            "old_password",
+            "password",
+            "password_changed",
+            "postal_address",
+            "privacy",
+            "roles",
+            "security_answer",
+            "security_question",
+            "status_change",
+            "telephone",
+            "unverified_email",
+        }
+        ignored_key_substrings = ("token",)
         person = {
             key: value
             for key, value in person.items()
             if not (
-                key in {"group_roles", "security_answer", "security_question"}
-                or "token" in key
+                key in ignored_keys or any(t in key for t in ignored_key_substrings)
             )
         }
 

--- a/fas2ipa/users.py
+++ b/fas2ipa/users.py
@@ -45,15 +45,19 @@ class Users(ObjectManager):
                 click.echo(f"finding users matching {pattern!r}")
             else:
                 click.echo(f"finding user {pattern!r}")
+
             result = self.fas.send_request(
                 "/user/list", req_params={"search": pattern}, auth=True, timeout=240,
             )
+
+            people = result["unapproved_people"] + result["people"]
             if users_start_at:
                 users_per_pattern = [
-                    u for u in result["people"] if u.username >= users_start_at
+                    u for u in people if u.username >= users_start_at
                 ]
             else:
-                users_per_pattern = result["people"]
+                users_per_pattern = people
+
             users_stats = self._migrate_users(users_per_pattern)
             stats.update(users_stats)
 

--- a/fas2ipa/users.py
+++ b/fas2ipa/users.py
@@ -86,6 +86,8 @@ class Users(ObjectManager):
                 for groupname, membership in person["group_roles"].items():
                     if groupname in self.config["groups"]["ignore"]:
                         continue
+                    if membership["role_status"] != "approved":
+                        continue
                     groups_to_member_usernames[groupname].append(person["username"])
                     if membership["role_type"] in ["administrator", "sponsor"]:
                         groups_to_sponsor_usernames[groupname].append(

--- a/fas2ipa/users.py
+++ b/fas2ipa/users.py
@@ -185,10 +185,12 @@ class Users(ObjectManager):
         username = person.pop("username")
         human_name = person.pop("human_name")
         status = person.pop("status")
+        email = person.pop("email")
         ircnick = person.pop("ircnick")
         locale = person.pop("locale")
         timezone = person.pop("timezone")
         gpg_keyid = person.pop("gpg_keyid")
+        ssh_key = person.pop("ssh_key")
         creation = person.pop("creation")
 
         # Fail if any details are left, i.e. unprocessed
@@ -226,6 +228,8 @@ class Users(ObjectManager):
                 "display_name": name,
                 "home_directory": f"/home/fedora/{username}",
                 "disabled": status != "active",
+                "mail": email,
+                "ipasshpubkey": ssh_key,
                 "fasircnick": ircnick.strip() if ircnick else None,
                 "faslocale": locale.strip() if locale else None,
                 "fastimezone": timezone.strip() if timezone else None,


### PR DESCRIPTION
If any detail of a user pulled from FAS isn't taken care of or explicitly ignored, provide a summary of the unprocessed details and fail the user.

@abompard, @ryanlerch: This is a draft because there are many details where we need to decide whether they need to go in, or be left out. See the output for my user:

````
vagrant@fas2ipa:~/fas2ipa (dev--fail-user-on-unprocessed-details)> poetry run fas2ipa --skip-groups --restrict-users nphilipp
Logged into FAS
Logged into IPA
Creating Agreements
Agreement with name "Fedora Project Contributor Agreement" already exists
finding user 'nphilipp'
1 found
nphilipp  Unprocessed details:                                                                       
	affiliation: None
	alias_enabled: None
	certificate_serial: 7
	comments: 
	country_code: DE
	email: <…shhhhh…>
	facsimile: <…shhhhh…>
	id: 100046
	internal_comments: None
	ipa_sync_status: None
	last_seen: 2020-09-08 16:34:54.675886+00:00
	latitude: None
	longitude: None
	memberships: ['{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}']
	old_password: <…shhhhh…>
	password: <…shhhhh…>
	password_changed: <…shhhhh…>
	postal_address: 
	privacy: False
	roles: ['{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}', '{…}']
	ssh_key: <…shhhhh…>
	status_change: 2008-08-16 23:44:51.574800+00:00
	telephone: <…shhhhh…>
	unverified_email: 
FAILED
100% (1 of 1) |################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Recording signers of the Fedora Project Contributor Agreement agreement
100% (1 of 1) |################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Adding members to groups
100% (36 of 36) |##############################################| Elapsed Time: 0:00:02 Time:  0:00:02
Adding sponsors to groups
100% (25 of 25) |##############################################| Elapsed Time: 0:00:01 Time:  0:00:01
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Successfully added 0 users.
Successfully edited 0 users.
Skipped 0 users.

Successfully created 0 groups.
Successfully edited 0 groups.

Total FAS groups: 0. Total groups changed in FreeIPA: 0
Total FAS users: 1. Total users changed in FreeIPA: 0

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

vagrant@fas2ipa:~/fas2ipa (dev--fail-user-on-unprocessed-details)>
````