### PR TITLE
More checks, firstly, and a whole slew of other things

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,7 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "devel/ansible/playbook.yml"
+    ansible.config_file = "devel/ansible/ansible.cfg"
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,8 +2,8 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/31/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-31-1.9.x86_64.vagrant-libvirt.box"
-  config.vm.box = "f31-cloud-libvirt"
+  config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-33-1.2.x86_64.vagrant-libvirt.box"
+  config.vm.box = "f33-cloud-libvirt"
   config.vm.hostname = "ipa.fas2ipa.test"
   config.vm.synced_folder ".", "/vagrant", type: "sshfs"
   config.hostmanager.enabled = true

--- a/config.toml.example
+++ b/config.toml.example
@@ -12,15 +12,32 @@ skip_spam = true
 [groups]
 # * for all
 search = "*"
-# Which groups should we ignore when creating and mapping?
-ignore = ["cla_fpca", "cla_done", "cla_fedora"]
 # Prefix the group names on import
 prefix = ""
 
-[fas]
+[fas.fedora]
 url = "https://admin.fedoraproject.org/accounts"
-# username =
-# password =
+# username = ""
+# password = ""
+
+[fas.fedora.groups]
+# Which groups should we ignore when creating and mapping?
+ignore = ["cla_fpca", "cla_done", "cla_fedora"]
+
+[[fas.fedora.agreement]]
+name = "Fedora Project Contributor Agreement"
+group_prerequisite = "cla_done"
+signed_groups = ["cla_fpca", "cla_done"]
+description_file = "FPCA.txt"
+
+[fas.centos]
+url = "https://accounts.centos.org"
+# username = ""
+# password = ""
+
+[fas.centos.groups]
+# Prefix the group names on import
+prefix = "centos-"
 
 [ipa]
 instances = ["ipa.fas2ipa.test"]
@@ -30,9 +47,3 @@ password = "adminPassw0rd!"
 # After too long a session can expire.
 # So we just trigger a re-atuh, every reauth_every imports.
 reauth_every = 300
-
-[[agreement]]
-name = "Fedora Project Contributor Agreement"
-group_prerequisite = "cla_done"
-signed_groups = ["cla_fpca", "cla_done"]
-description_file = "FPCA.txt"

--- a/config.toml.example
+++ b/config.toml.example
@@ -6,6 +6,9 @@ chunks = 30
 # Record and replay requests to FAS (for testing)
 replay = false
 
+# How many retries before failing a request
+retries = 2
+
 [users]
 skip_spam = true
 

--- a/config.toml.example
+++ b/config.toml.example
@@ -20,6 +20,7 @@ prefix = ""
 
 [fas.fedora]
 url = "https://admin.fedoraproject.org/accounts"
+email_domain = "fedoraproject.org"
 # username = ""
 # password = ""
 
@@ -35,6 +36,7 @@ description_file = "FPCA.txt"
 
 [fas.centos]
 url = "https://accounts.centos.org"
+email_domain = "centos.org"
 # username = ""
 # password = ""
 

--- a/devel/ansible/ansible.cfg
+++ b/devel/ansible/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+interpreter_python = auto

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Install RPM packages
   dnf:
-      name: ['git', 'vim', 'poetry', 'python3-pip', 'freeipa-server']
+      name: ['git', 'vim', 'poetry', 'python3-pip', 'freeipa-server', 'gcc', 'python3-devel']
       state: present
 
 - name: install python deps with poetry

--- a/devel/ansible/roles/dev/tasks/main.yml
+++ b/devel/ansible/roles/dev/tasks/main.yml
@@ -11,6 +11,11 @@
   args:
     chdir: /vagrant/
 
+- name: uninstall existing freeipa server
+  shell: test -f /var/log/ipaserver-install.log && ipa-server-install --uninstall --unattended
+  ignore_errors: yes
+  changed_when: "False"
+
 - name: install freeipa server
   shell: ipa-server-install -a adminPassw0rd! --hostname=ipa.fas2ipa.test -r FAS2IPA.TEST -p adminPassw0rd! -n fas2ipa.test -U
 

--- a/fas2ipa/agreements.py
+++ b/fas2ipa/agreements.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Sequence
 
 import click
 import python_freeipa
@@ -8,7 +8,7 @@ from .status import Status, print_status
 from .utils import ObjectManager
 
 
-def find_requirements(groups, prereq_id):
+def find_requirements(groups: Sequence[dict], prereq_id: int) -> List[str]:
     dependent_groups = []
     for group in groups:
         if group["prerequisite_id"] == prereq_id:

--- a/fas2ipa/agreements.py
+++ b/fas2ipa/agreements.py
@@ -17,7 +17,7 @@ def find_requirements(groups, prereq_id):
 
 
 class Agreements(ObjectManager):
-    def create(self):
+    def push_to_ipa(self):
         click.echo("Creating Agreements")
         for agreement in self.config.get("agreement"):
             with open(agreement["description_file"], "r") as f:
@@ -63,12 +63,15 @@ class Agreements(ObjectManager):
     def record_group_requirements(self, groups):
         for agreement in self.config.get("agreement"):
 
-            toplevel_prereq = self.fas.send_request(
-                "/group/list",
-                req_params={"search": agreement["group_prerequisite"]},
-                auth=True,
-                timeout=240,
-            )["groups"][0]["id"]
+            for group in groups:
+                if group["name"] == agreement["group_prerequisite"]:
+                    toplevel_prereq = group["id"]
+                    break
+            else:
+                raise RuntimeError(
+                    f"Toplevel prerequisite {agreement['group_prerequisite']} for"
+                    f" agreement {agreement['name']!r} not found."
+                )
 
             agreement_required = find_requirements(groups, toplevel_prereq)
 

--- a/fas2ipa/agreements.py
+++ b/fas2ipa/agreements.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict, List
+
 import click
 import python_freeipa
 import progressbar
@@ -19,83 +21,85 @@ def find_requirements(groups, prereq_id):
 class Agreements(ObjectManager):
     def push_to_ipa(self):
         click.echo("Creating Agreements")
-        for agreement in self.config.get("agreement"):
-            with open(agreement["description_file"], "r") as f:
-                agreement_description = f.read()
-            try:
-                self.ipa._request(
-                    "fasagreement_add",
-                    agreement["name"],
-                    {"description": agreement_description},
-                )
-            except python_freeipa.exceptions.DuplicateEntry as e:
-                print_status(Status.SKIPPED, str(e))
+        for fas_name, fas_config in self.config["fas"].items():
+            for agreement in fas_config.get("agreement", ()):
+                with open(agreement["description_file"], "r") as f:
+                    agreement_description = f.read()
+                try:
+                    self.ipa._request(
+                        "fasagreement_add",
+                        agreement["name"],
+                        {"description": agreement_description},
+                    )
+                except python_freeipa.exceptions.DuplicateEntry as e:
+                    print_status(Status.SKIPPED, str(e))
 
-    def record_user_signatures(self, agreements_to_usernames):
+    def record_user_signatures(self, agreements_to_usernames: Dict[str, List[str]]):
         if self.config["skip_user_signature"]:
             return
 
-        for agreement in self.config.get("agreement"):
-            click.echo(f"Recording signers of the {agreement['name']} agreement")
-            signers = agreements_to_usernames.get(agreement["name"], [])
-            if not signers:
-                click.echo("Nothing to do.")
-                continue
-            counter = 0
-            with progressbar.ProgressBar(
-                max_value=len(signers), redirect_stdout=True
-            ) as bar:
-                for chunk in self.chunks(signers):
-                    counter += len(chunk)
-                    self.check_reauth(counter)
-                    response = self.ipa._request(
-                        "fasagreement_add_user", agreement["name"], {"user": chunk},
-                    )
-                    for msg in response["failed"]["memberuser"]["user"]:
-                        if msg[1] != "This entry is already a member":
-                            print_status(
-                                Status.FAILED,
-                                f"Could not mark {msg[0]} as having signed "
-                                f"{agreement['name']}: {msg[1]}",
-                            )
-                    bar.update(counter)
-
-    def record_group_requirements(self, groups):
-        for agreement in self.config.get("agreement"):
-
-            for group in groups:
-                if group["name"] == agreement["group_prerequisite"]:
-                    toplevel_prereq = group["id"]
-                    break
-            else:
-                raise RuntimeError(
-                    f"Toplevel prerequisite {agreement['group_prerequisite']} for"
-                    f" agreement {agreement['name']!r} not found."
-                )
-
-            agreement_required = find_requirements(groups, toplevel_prereq)
-
-            for dep_name in progressbar.progressbar(
-                agreement_required, redirect_stdout=True
-            ):
-                result = self.ipa._request(
-                    "fasagreement_add_group",
-                    agreement["name"],
-                    {"group": self.config["groups"]["prefix"] + dep_name},
-                )
-                if result["completed"]:
-                    print_status(
-                        Status.ADDED,
-                        f"Marking {dep_name} as requiring the {agreement['name']}",
-                    )
-                else:
-                    error_msg = result["failed"]["member"]["group"][0][1]
-                    if error_msg == "This entry is already a member":
-                        print_status(
-                            Status.SKIPPED,
-                            f"{dep_name} already requires {agreement['name']}",
+        for fas_name, fas_conf in self.config["fas"].items():
+            for agreement in fas_conf.get("agreement", ()):
+                click.echo(f"Recording signers of the {agreement['name']} agreement")
+                signers = agreements_to_usernames.get(agreement["name"], [])
+                if not signers:
+                    click.echo("Nothing to do.")
+                    continue
+                counter = 0
+                with progressbar.ProgressBar(
+                    max_value=len(signers), redirect_stdout=True
+                ) as bar:
+                    for chunk in self.chunks(signers):
+                        counter += len(chunk)
+                        self.check_reauth(counter)
+                        response = self.ipa._request(
+                            "fasagreement_add_user", agreement["name"], {"user": chunk},
                         )
-                    elif error_msg == "no such entry":
-                        print_status(Status.FAILED, f"No group named {dep_name}")
+                        for msg in response["failed"]["memberuser"]["user"]:
+                            if msg[1] != "This entry is already a member":
+                                print_status(
+                                    Status.FAILED,
+                                    f"Could not mark {msg[0]} as having signed "
+                                    f"{agreement['name']}: {msg[1]}",
+                                )
+                        bar.update(counter)
+
+    def record_group_requirements(self, groups: Dict[str, List[Dict[str, Any]]]):
+        for fas_name, fas_conf in self.config["fas"].items():
+            for agreement in fas_conf.get("agreement", ()):
+                for group in groups[fas_name]:
+                    if group["name"] == agreement["group_prerequisite"]:
+                        toplevel_prereq = group["id"]
+                        break
+                else:
+                    raise RuntimeError(
+                        f"Toplevel prerequisite {agreement['group_prerequisite']} for"
+                        f" agreement {agreement['name']!r} not found."
+                    )
+
+                agreement_required = find_requirements(groups[fas_name], toplevel_prereq)
+
+                for dep_name in progressbar.progressbar(
+                    agreement_required, redirect_stdout=True
+                ):
+                    result = self.ipa._request(
+                        "fasagreement_add_group",
+                        agreement["name"],
+                        {"group": fas_conf["groups"].get("prefix", "") + dep_name},
+                    )
+                    if result["completed"]:
+                        print_status(
+                            Status.ADDED,
+                            f"Marking {dep_name} as requiring the {agreement['name']}",
+                        )
                     else:
-                        print(result["failed"])
+                        error_msg = result["failed"]["member"]["group"][0][1]
+                        if error_msg == "This entry is already a member":
+                            print_status(
+                                Status.SKIPPED,
+                                f"{dep_name} already requires {agreement['name']}",
+                            )
+                        elif error_msg == "no such entry":
+                            print_status(Status.FAILED, f"No group named {dep_name}")
+                        else:
+                            print(result["failed"])

--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -113,7 +113,7 @@ def cli(
 
     agreements = Agreements(config, instances, fas)
     if config.get("agreement"):
-        agreements.create()
+        agreements.push_to_ipa()
 
     if not skip_groups:
         groups_mgr = Groups(config, instances, fas, agreements=agreements)

--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -115,9 +115,11 @@ def cli(
     if config.get("agreement"):
         agreements.create()
 
-    groups = Groups(config, instances, fas, agreements=agreements)
-    groups_stats = groups.migrate_groups()
-    stats.update(groups_stats)
+    if not skip_groups:
+        groups_mgr = Groups(config, instances, fas, agreements=agreements)
+        groups = groups_mgr.pull_from_fas()
+        groups_stats = groups_mgr.push_to_ipa(groups)
+        stats.update(groups_stats)
 
     users = Users(config, instances, fas, agreements=agreements)
     users_stats = users.migrate_users(

--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -65,7 +65,7 @@ class FASWrapper:
             return self.fas.send_request(url, *args, **kwargs)
 
 
-@click.command()
+@click.command(context_settings={"help_option_names": ("-h", "--help")})
 @click.option("--skip-groups", is_flag=True, help="Skip group creation.")
 @click.option(
     "--skip-user-add", is_flag=True, help="Don't add or update users.",

--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -66,24 +66,24 @@ class FASWrapper:
 
 
 @click.command()
-@click.option("--skip-groups", is_flag=True, help="Skip group creation")
+@click.option("--skip-groups", is_flag=True, help="Skip group creation.")
 @click.option(
-    "--skip-user-add", is_flag=True, help="Don't add or update users",
+    "--skip-user-add", is_flag=True, help="Don't add or update users.",
 )
 @click.option(
-    "--skip-user-membership", is_flag=True, help="Don't add users to groups",
+    "--skip-user-membership", is_flag=True, help="Don't add users to groups.",
 )
 @click.option(
     "--skip-user-signature",
     is_flag=True,
-    help="Don't store users' signatures of agreements",
+    help="Don't store users' signatures of agreements.",
 )
-@click.option("--users-start-at", help="Start migrating users at that (partial) name")
+@click.option("--users-start-at", help="Start migrating users at that (partial) name.")
 @click.option(
     "--restrict-users",
     "-u",
     multiple=True,
-    help="Restrict users to supplied glob pattern(s)",
+    help="Restrict users to supplied glob pattern(s).",
 )
 def cli(
     skip_groups,

--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -217,7 +217,7 @@ def cli(
             groups_stats = groups_mgr.push_to_ipa(dataset["groups"])
             stats.update(groups_stats)
 
-        users_stats = users_mgr.push_to_ipa(dataset["users"])
+        users_stats = users_mgr.push_to_ipa(dataset["users"], users_start_at, restrict_users)
         stats.update(users_stats)
 
     stats.print()

--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -87,6 +87,7 @@ class FASWrapper:
     type=click.Path(file_okay=True),
     help="Write data into/read data from this file.",
 )
+@click.option("--conflicts-file", default=None, help="Write found conflicts into this file.")
 @click.option("--force-overwrite", is_flag=True, help="Overwrite file if it exists.")
 @click.option("--skip-groups", is_flag=True, help="Skip group creation.")
 @click.option(
@@ -112,6 +113,7 @@ def cli(
     push,
     check,
     dataset_file,
+    conflicts_file,
     force_overwrite,
     skip_groups,
     skip_user_add,
@@ -198,12 +200,15 @@ def cli(
 
     if check:
         users_to_conflicts = users_mgr.find_user_conflicts(dataset["users"])
-        if users_to_conflicts:
-            dataset["users_to_conflicts"] = users_to_conflicts
-
         groups_to_conflicts = groups_mgr.find_group_conflicts(dataset["groups"])
-        if groups_to_conflicts:
-            dataset["groups_to_conflicts"] = groups_to_conflicts
+
+        if conflicts_file:
+            conflicts = {}
+            if users_to_conflicts:
+                conflicts["users"] = users_to_conflicts
+            if groups_to_conflicts:
+                conflicts["groups"] = groups_to_conflicts
+            save_data(conflicts, conflicts_file, force_overwrite=force_overwrite)
 
     if pull and dataset_file:
         save_data(munch.unmunchify(dataset), dataset_file, force_overwrite=force_overwrite)

--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -115,16 +115,20 @@ def cli(
     if config.get("agreement"):
         agreements.push_to_ipa()
 
-    if not skip_groups:
-        groups_mgr = Groups(config, instances, fas, agreements=agreements)
-        groups = groups_mgr.pull_from_fas()
-        groups_stats = groups_mgr.push_to_ipa(groups)
-        stats.update(groups_stats)
-
     users_mgr = Users(config, instances, fas, agreements=agreements)
+    groups_mgr = Groups(config, instances, fas, agreements=agreements)
+
+    if not skip_groups:
+        groups = groups_mgr.pull_from_fas()
+
     users = users_mgr.pull_from_fas(
         users_start_at=users_start_at, restrict_users=restrict_users
     )
+
+    if not skip_groups:
+        groups_stats = groups_mgr.push_to_ipa(groups)
+        stats.update(groups_stats)
+
     users_stats = users_mgr.push_to_ipa(users)
     stats.update(users_stats)
 

--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -121,10 +121,11 @@ def cli(
         groups_stats = groups_mgr.push_to_ipa(groups)
         stats.update(groups_stats)
 
-    users = Users(config, instances, fas, agreements=agreements)
-    users_stats = users.migrate_users(
+    users_mgr = Users(config, instances, fas, agreements=agreements)
+    users = users_mgr.pull_from_fas(
         users_start_at=users_start_at, restrict_users=restrict_users
     )
+    users_stats = users_mgr.push_to_ipa(users)
     stats.update(users_stats)
 
     stats.print()

--- a/fas2ipa/groups.py
+++ b/fas2ipa/groups.py
@@ -151,12 +151,15 @@ class Groups(ObjectManager):
 
             groups_to_conflicts[group_name] = group_conflicts = defaultdict(list)
 
-            conflicting_group_message = f"Conflicting group {group_name} in: {{}}".format(
-                ", ".join(fas_names)
-            )
+            group_conflicts["same_group_name"] = {"fas_names": fas_names}
 
-            click.echo(conflicting_group_message)
-            group_conflicts["group_name"].append(conflicting_group_message)
+            if group_conflicts:
+                click.echo(f"Conflicts for group {group_name}:")
+                for key, details in group_conflicts.items():
+                    if key == "same_group_name":
+                        click.echo(f"\tSame group name between: {', '.join(details['fas_names'])}")
+                    else:
+                        raise RuntimeError(f"Unknown conflicts key: {key}")
 
         click.echo("Done checking group conflicts.")
         click.echo(f"Found {len(groups_to_conflicts)} groups with conflicts.")

--- a/fas2ipa/groups.py
+++ b/fas2ipa/groups.py
@@ -28,8 +28,7 @@ class Groups(ObjectManager):
             timeout=240,
         )
         fas_groups = [
-            g
-            for g in fas_groups["groups"]
+            g for g in fas_groups["groups"]
             if g["name"] not in self.config["groups"]["ignore"]
         ]
         fas_groups.sort(key=lambda g: g["name"])

--- a/fas2ipa/groups.py
+++ b/fas2ipa/groups.py
@@ -19,11 +19,7 @@ class Groups(ObjectManager):
             req_params={"search": self.config["groups"]["search"]},
             auth=True,
             timeout=240,
-        )
-        groups = [
-            g for g in groups["groups"]
-            if g["name"] not in self.config["groups"]["ignore"]
-        ]
+        )["groups"]
         groups.sort(key=lambda g: g["name"])
         click.echo(f"Got {len(groups)} groups!")
 
@@ -35,6 +31,11 @@ class Groups(ObjectManager):
         counter = 0
 
         # Start by creating groups
+        groups = [
+            g for g in groups
+            if g["name"] not in self.config["groups"].get("ignore", ())
+        ]
+
         name_max_length = max([len(g["name"]) for g in groups])
 
         click.echo("Pushing group information to IPA...")

--- a/fas2ipa/users.py
+++ b/fas2ipa/users.py
@@ -358,7 +358,7 @@ class Users(ObjectManager):
                 for chunk in self.chunks(members):
                     counter += len(chunk)
                     self.check_reauth(counter)
-                    added = set(chunk[:])
+                    added = set(chunk)
                     try:
                         if category == "members":
                             self.ipa.group_add_member(

--- a/fas2ipa/utils.py
+++ b/fas2ipa/utils.py
@@ -1,6 +1,7 @@
 import json
 import pathlib
 import random
+from collections import defaultdict
 from typing import Union
 
 import click
@@ -87,6 +88,8 @@ def save_data(data: dict, fpath: Union[str, pathlib.Path], force_overwrite: bool
             toml.dump(data, fobj)
         elif suffix == ".yaml":
             import yaml
+            yaml.add_representer(set, yaml.representer.SafeRepresenter.represent_list)
+            yaml.add_representer(defaultdict, yaml.representer.SafeRepresenter.represent_dict)
             yaml.dump(data, fobj)
         else:
             json.dump(data, fobj, indent=2)

--- a/fas2ipa/utils.py
+++ b/fas2ipa/utils.py
@@ -89,4 +89,4 @@ def save_data(data: dict, fpath: Union[str, pathlib.Path], force_overwrite: bool
             import yaml
             yaml.dump(data, fobj)
         else:
-            json.dump(data, fobj)
+            json.dump(data, fobj, indent=2)

--- a/fas2ipa/utils.py
+++ b/fas2ipa/utils.py
@@ -19,10 +19,10 @@ def re_auth(config, instances):
 
 
 class ObjectManager:
-    def __init__(self, config, ipa_instances, fas):
+    def __init__(self, config, ipa_instances, fas_instances):
         self.config = config
         self.ipa_instances = ipa_instances
-        self.fas = fas
+        self.fas_instances = fas_instances
 
     @property
     def ipa(self):

--- a/fas2ipa/utils.py
+++ b/fas2ipa/utils.py
@@ -1,6 +1,10 @@
+import json
+import pathlib
 import random
+from typing import Union
 
 import click
+import toml
 
 
 # def chunks(data, n):
@@ -31,3 +35,58 @@ class ObjectManager:
     def chunks(self, items):
         size = self.config["chunks"]
         return [items[x : x + size] for x in range(0, len(items), size)]
+
+
+def load_data(fpath: Union[str, pathlib.Path]) -> dict:
+    """Load dictionary data from a JSON, YAML, or TOML file.
+
+    The file format will be determined from the extension of the file name.
+
+    :param fpath:   The file path from which to load.
+
+    :return:        The loaded data as a dictionary.
+    """
+    if not isinstance(fpath, pathlib.Path):
+        fpath = pathlib.Path(fpath)
+
+    suffix = fpath.suffix.lower()
+
+    if suffix == ".toml":
+        data = toml.loads(fpath.read_text())
+    elif suffix == ".yaml":
+        import yaml
+        with fpath.open("r") as fobj:
+            data = yaml.safe_load(fobj)
+    else:
+        data = json.loads(fpath.read_text())
+
+    return data
+
+
+def save_data(data: dict, fpath: Union[str, pathlib.Path], force_overwrite: bool = False):
+    """Save a dictionary object to a JSON, YAML, or TOML file.
+
+    The file format will be determined from the extension of the file name.
+
+    :param data:            The data to be saved.
+    :param fpath:           The file path to be saved into.
+    :param force_overwrite: Whether an existing file should be overwritten.
+    """
+    if not isinstance(fpath, pathlib.Path):
+        fpath = pathlib.Path(fpath)
+
+    suffix = fpath.suffix.lower()
+
+    if force_overwrite:
+        mode = "w"
+    else:
+        mode = "x"
+
+    with fpath.open(mode) as fobj:
+        if suffix == ".toml":
+            toml.dump(data, fobj)
+        elif suffix == ".yaml":
+            import yaml
+            yaml.dump(data, fobj)
+        else:
+            json.dump(data, fobj)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ python-fedora = "^1.0.0"
 progressbar2 = "^3.51.3"
 vcrpy = "^4.0.2"
 colorama = "^0.4.3"
+munch = "^2.0.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.7.9"


### PR DESCRIPTION
Apart from many auxiliary changes:

- Separate logic pulling data from FAS and pushing into IPA and offer to do either one or both, as well as saving into/loading from a in intermediary file (which is needed to split both activities). This inherently also avoids querying FAS for the agreement-related groups a second time, i.e. avoids a potential race condition (not that querying users, groups in separate steps doesn't :wink:).
- Query both Fedora and CentOS FAS instances in one go to enable…
- Check for conflicts between Fedora and CentOS datasets, e.g. users with the same name but different email addresses.

Draft PR for the time being as right now especially the latter part just produces free-form output and I want to hear from you if this is what we want.