### PR TITLE
Sort out issues with --check option 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(2) do |config|
   config.hostmanager.manage_host = true
   config.vm.provider :libvirt do |libvirt|
     libvirt.cpus = 2
-    libvirt.memory = 2048 
+    libvirt.memory = 4096
   end
 
   # Vagrant adds '127.0.0.1 ipa.example.com ipa' as the first line in /etc/hosts

--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -13,7 +13,7 @@ from .statistics import Stats
 from .users import Users
 from .groups import Groups
 from .agreements import Agreements
-from .utils import load_data, save_data
+from .utils import load_data, report_conflicts, save_data
 
 
 class FASWrapper:
@@ -217,16 +217,21 @@ def cli(
         )
 
     if check:
-        users_to_conflicts = users_mgr.find_user_conflicts(dataset["users"])
-        groups_to_conflicts = groups_mgr.find_group_conflicts(dataset["groups"])
+        if dataset_file:
+            users_to_conflicts = users_mgr.find_user_conflicts(dataset["users"])
+            groups_to_conflicts = groups_mgr.find_group_conflicts(dataset["groups"])
 
-        if conflicts_file:
             conflicts = {}
             if users_to_conflicts:
                 conflicts["users"] = users_to_conflicts
             if groups_to_conflicts:
                 conflicts["groups"] = groups_to_conflicts
-            save_data(conflicts, conflicts_file, force_overwrite=force_overwrite)
+
+            if conflicts_file:
+                save_data(conflicts, conflicts_file, force_overwrite=force_overwrite)
+        else:
+            conflicts = load_data(conflicts_file)
+        report_conflicts(conflicts)
 
     if pull and dataset_file:
         save_data(munch.unmunchify(dataset), dataset_file, force_overwrite=force_overwrite)

--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -139,7 +139,7 @@ def cli(
     if all(x is None for x in all_ops):
         raise click.BadOptionUsage(
             option_name=("--pull", "--push", "--check"),
-            message="Neither pulling, pushing not checking. Bailing out.",
+            message="Neither pulling, pushing nor checking. Bailing out.",
         )
     elif not dataset_file and (not pull or not push):
         raise click.BadOptionUsage(

--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -134,6 +134,8 @@ def cli(
     else:
         pull = push = check = True
 
+    all_ops = (push, pull, check)
+
     if all(x is None for x in all_ops):
         raise click.BadOptionUsage(
             option_name=("--pull", "--push", "--check"),

--- a/fas2ipa/groups.py
+++ b/fas2ipa/groups.py
@@ -153,14 +153,6 @@ class Groups(ObjectManager):
 
             group_conflicts["same_group_name"] = {"fas_names": fas_names}
 
-            if group_conflicts:
-                click.echo(f"Conflicts for group {group_name}:")
-                for key, details in group_conflicts.items():
-                    if key == "same_group_name":
-                        click.echo(f"\tSame group name between: {', '.join(details['fas_names'])}")
-                    else:
-                        raise RuntimeError(f"Unknown conflicts key: {key}")
-
         click.echo("Done checking group conflicts.")
         click.echo(f"Found {len(groups_to_conflicts)} groups with conflicts.")
 

--- a/fas2ipa/users.py
+++ b/fas2ipa/users.py
@@ -543,30 +543,7 @@ class Users(ObjectManager):
 
             if user_conflicts:
                 users_to_conflicts[username] = user_conflicts
-                click.echo(f"Conflicts for user {username}:")
-                for key, details in user_conflicts.items():
-                    if key == "circular_email":
-                        click.echo("\tCircular email address:")
-                        for item in details:
-                            click.echo(f"\t\t{item['fas_name']}: {item['email_address']}")
-                    elif key == "email_pointing_to_other_fas":
-                        click.echo("\tEmail address points to other FAS:")
-                        for item in details:
-                            click.echo(
-                                f"\t\tEmail address {item['email_address']} for"
-                                f" {', '.join(item['src_fas_names'])} points to"
-                                f" {item['tgt_fas_name']}."
-                            )
-                    elif key == "email_address_conflicts":
-                        click.echo("\tConflicting email addresses between FAS instances:")
-                        for item in details:
-                            click.echo(
-                                f"\t\t{item['email_address']}: {', '.join(item['fas_names'])}"
-                            )
-                    else:
-                        raise RuntimeError(f"Unknown conflicts key: {key}")
 
         click.echo("Done checking user conflicts.")
-        click.echo(f"Found {len(users_to_conflicts)} users with conflicts.")
 
         return users_to_conflicts


### PR DESCRIPTION
* Fixes a logical error which messes up the default (do everything) if no specific partial action (pull, check, pull) is chosen. 
* Data is validated (or saved conflict data is summarized) always by default (i.e. unless `--no-check` is given).
* Bump the Vagrant box memory to 4G because the script ran into OOM on me on real-world data.

Fixes: #22