### PR TITLE
Don't trip over sets when saving to JSON

### DIFF
--- a/fas2ipa/cli.py
+++ b/fas2ipa/cli.py
@@ -169,20 +169,30 @@ def cli(
     config["skip_user_membership"] = skip_user_membership
     config["skip_user_signature"] = skip_user_signature
 
+    # If dataset or conlicts files should be written later, bail out before overwriting
+    # an existing file (unless force_overwrite is set). This will be checked again later
+    # to avoid race conditions.
+
     if dataset_file:
         dataset_file = pathlib.Path(dataset_file)
+
+        if pull and dataset_file.exists() and not force_overwrite:
+            raise click.ClickException(
+                f"Refusing to overwrite '{dataset_file}', use --force-overwrite to override."
+            )
+
+    if conflicts_file:
+        conflicts_file = pathlib.Path(conflicts_file)
+
+        if check and dataset_file and conflicts_file.exists() and not force_overwrite:
+            raise click.ClickException(
+                f"Refusing to overwrite '{conflicts_file}', use --force-overwrite to override."
+            )
 
     if dataset_file and not pull:
         dataset = load_data(dataset_file)
     else:
         dataset = {}
-
-    # If the dataset should be written later, bail out before overwriting an existing file (unless
-    # force_overwrite is set). This will be checked again later to avoid race conditions.
-    if dataset_file and pull and dataset_file.exists() and not force_overwrite:
-        raise click.ClickException(
-            f"Refusing to overwrite '{dataset_file}', use --force-overwrite to override."
-        )
 
     fas_instances = {}
 

--- a/fas2ipa/utils.py
+++ b/fas2ipa/utils.py
@@ -64,6 +64,15 @@ def load_data(fpath: Union[str, pathlib.Path]) -> dict:
     return data
 
 
+class CustomJSONEncoder(json.JSONEncoder):
+    """JSON encoder which serializes sets as lists"""
+
+    def default(self, obj):
+        if isinstance(obj, set):
+            return list(obj)
+        return super().default(obj)
+
+
 def save_data(data: dict, fpath: Union[str, pathlib.Path], force_overwrite: bool = False):
     """Save a dictionary object to a JSON, YAML, or TOML file.
 
@@ -92,7 +101,7 @@ def save_data(data: dict, fpath: Union[str, pathlib.Path], force_overwrite: bool
             yaml.add_representer(defaultdict, yaml.representer.SafeRepresenter.represent_dict)
             yaml.dump(data, fobj)
         else:
-            json.dump(data, fobj, indent=2)
+            json.dump(data, fobj, indent=2, cls=CustomJSONEncoder)
 
 
 def report_conflicts(conflicts):


### PR DESCRIPTION
JSON doesn't know sets as a data type, therefore the default encoder doesn't serialize them. This PR implements a custom encoder which serializes sets as lists because we don't care—the sets are just an implementation detail of how conflicts are detected and the reporting just iterates over the objects.

Also, prevent inadvertent overwriting of the conflicts file early (even just loading a real-world size dataset file takes some time).