### PR TITLE
Bump memory to 4GB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(2) do |config|
   config.hostmanager.manage_host = true
   config.vm.provider :libvirt do |libvirt|
     libvirt.cpus = 2
-    libvirt.memory = 2048 
+    libvirt.memory = 4096
   end
 
   # Vagrant adds '127.0.0.1 ipa.example.com ipa' as the first line in /etc/hosts


### PR DESCRIPTION
The `fas2ipa` script will get killed when attempting to process all
Fedora users because the box runs out of memory.

Signed-off-by: Nils Philippsen <nils@redhat.com>