### PR TITLE
Implement umbrella groups

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -31,6 +31,10 @@ email_domain = "fedoraproject.org"
 # Which groups should we ignore when creating and mapping?
 ignore = ["cla_fpca", "cla_done", "cla_fedora"]
 
+[fas.fedora.groups.umbrella]
+name = "fedora-contributor"
+description = "Fedora contributors"
+
 [[fas.fedora.agreement]]
 name = "Fedora Project Contributor Agreement"
 group_prerequisite = "cla_done"

--- a/fas2ipa/groups.py
+++ b/fas2ipa/groups.py
@@ -55,7 +55,7 @@ class Groups(ObjectManager):
                 if g["name"] not in fas_conf["groups"].get("ignore", ())
             ]
 
-            name_max_length = max([len(g["name"]) for g in fas_groups])
+            name_max_length = max((len(g["name"]) for g in fas_groups))
 
             for group in progressbar.progressbar(fas_groups, redirect_stdout=True):
                 counter += 1

--- a/fas2ipa/groups.py
+++ b/fas2ipa/groups.py
@@ -48,6 +48,20 @@ class Groups(ObjectManager):
 
             fas_conf = self.config["fas"][fas_name]
 
+            # Start by creating the umbrella group, if any
+            umbrella_group = fas_conf["groups"].get("umbrella")
+            if umbrella_group:
+                click.echo(f"Ensuring umbrella group {umbrella_group['name']} exists...")
+                name_max_length = max((len(g["name"]) for g in fas_groups))
+                click.echo(umbrella_group["name"].ljust(name_max_length + 2), nl=False)
+                status = self._write_group_to_ipa(fas_name, umbrella_group, from_fas=False)
+                print_status(status)
+                if status == Status.ADDED:
+                    added += 1
+                elif status == Status.UPDATED:
+                    edited += 1
+                umbrella_members = set()
+
             # Start by creating groups
             fas_groups = [
                 g
@@ -78,6 +92,25 @@ class Groups(ObjectManager):
                     added += 1
                 elif status == Status.UPDATED:
                     edited += 1
+                if umbrella_group and status in (Status.ADDED, Status.UPDATED, Status.UNMODIFIED):
+                    umbrella_members.add(
+                        fas_conf["groups"].get("prefix", "") + group["name"].lower()
+                    )
+
+            if umbrella_group:
+                ipa_group = self.ipa.group_show(umbrella_group["name"])
+                existing_umbrella_members = set(ipa_group.get("member_group", []))
+                new_umbrella_members = umbrella_members - existing_umbrella_members
+                if not new_umbrella_members:
+                    click.echo(f"No new members to add to umbrella group {umbrella_group['name']}")
+                else:
+                    click.echo(
+                        f"Adding {len(new_umbrella_members)} new groups to umbrella group"
+                        f" {umbrella_group['name']}"
+                    )
+                    self.ipa.group_add_member(
+                        umbrella_group["name"], groups=list(new_umbrella_members)
+                    )
 
             click.echo(f"Done with {fas_name}")
 
@@ -89,50 +122,62 @@ class Groups(ObjectManager):
 
         return dict(groups_added=added, groups_edited=edited, groups_counter=counter,)
 
-    def _write_group_to_ipa(self, fas_name: str, group: dict):
-        name = (
-            self.config["fas"][fas_name]["groups"].get("prefix", "")
-            + group["name"].lower()
-        )
-        # calculate the IRC channel (FAS has 2 fields, freeipa-fas has a single one )
-        # if we have an irc channel defined. try to generate the irc:// uri
-        # there are a handful of groups that have an IRC server defined (freenode), but
-        # no channel, which is kind of useless, so we don't handle that case.
-        irc_channel = group.get("irc_channel")
-        irc_string = None
-        if irc_channel:
-            if irc_channel[0] == "#":
-                irc_channel = irc_channel[1:]
-            irc_network = group.get("irc_network").lower()
-            if "gimp" in irc_network:
-                irc_string = f"irc://irc.gimp.org/#{irc_channel}"
-            elif "oftc" in irc_network:
-                irc_string = f"irc://irc.oftc.net/#{irc_channel}"
+    def _write_group_to_ipa(self, fas_name: str, group: dict, from_fas: bool = True):
+        if from_fas:
+            # transform FAS group info into what IPA expects
+            name = (
+                self.config["fas"][fas_name]["groups"].get("prefix", "")
+                + group["name"].lower()
+            )
+            # calculate the IRC channel (FAS has 2 fields, freeipa-fas has a single one )
+            # if we have an irc channel defined. try to generate the irc:// uri
+            # there are a handful of groups that have an IRC server defined (freenode), but
+            # no channel, which is kind of useless, so we don't handle that case.
+            irc_channel = group.get("irc_channel")
+            irc_string = None
+            if irc_channel:
+                if irc_channel[0] == "#":
+                    irc_channel = irc_channel[1:]
+                irc_network = group.get("irc_network").lower()
+                if "gimp" in irc_network:
+                    irc_string = f"irc://irc.gimp.org/#{irc_channel}"
+                elif "oftc" in irc_network:
+                    irc_string = f"irc://irc.oftc.net/#{irc_channel}"
+                else:
+                    # the remainder of the entries here are either blank or
+                    # freenode, so we freenode them all.
+                    irc_string = f"irc://irc.freenode.net/#{irc_channel}"
+            url = group.get("url")
+            if not url:
+                url = None
             else:
-                # the remainder of the entries here are either blank or
-                # freenode, so we freenode them all.
-                irc_string = f"irc://irc.freenode.net/#{irc_channel}"
-        url = group.get("url")
-        if not url:
-            url = None
+                url = url.strip()
+            mailing_list = group.get("mailing_list")
+            if not mailing_list:
+                mailing_list = None
+            else:
+                if "@" not in mailing_list:
+                    mailing_list = f"{mailing_list}@lists.fedoraproject.org"
+                mailing_list = mailing_list.strip()
+                mailing_list = mailing_list.rstrip(".")
+                mailing_list = mailing_list.lower()
+
+            group_args = {
+                "description": group["display_name"].strip(),
+                "fasurl": url,
+                "fasmailinglist": mailing_list,
+                "fasircchannel": irc_string,
+            }
         else:
-            url = url.strip()
-        mailing_list = group.get("mailing_list")
-        if not mailing_list:
-            mailing_list = None
-        else:
-            if "@" not in mailing_list:
-                mailing_list = f"{mailing_list}@lists.fedoraproject.org"
-            mailing_list = mailing_list.strip()
-            mailing_list = mailing_list.rstrip(".")
-            mailing_list = mailing_list.lower()
-        group_args = dict(
-            description=group["display_name"].strip(),
-            fasgroup=True,
-            fasurl=url,
-            fasmailinglist=mailing_list,
-            fasircchannel=irc_string,
-        )
+            name = group["name"]
+            group_args = {
+                k: v for k, v in group.items() if k in (
+                    "description", "fasurl", "fasmailinglist", "fasircchannel"
+                )
+            }
+
+        group["fasgroup"] = True
+
         try:
             self.ipa.group_add(name, **group_args)
             return Status.ADDED


### PR DESCRIPTION
This lets us give all Fedora contributors, i.e. members of at least one non-CLA group, access to people.fedoraproject.org.