### PR TITLE
Don't overwrite user data in IPA by default

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -27,6 +27,10 @@ email_domain = "fedoraproject.org"
 # username = ""
 # password = ""
 
+[fas.fedora.users]
+# whether to overwrite fields when a user exists
+# overwrite_data = true
+
 [fas.fedora.groups]
 # Which groups should we ignore when creating and mapping?
 ignore = ["cla_fpca", "cla_done", "cla_fedora"]


### PR DESCRIPTION
This should be the safeir way for importing CentOS users on top of their
existing Fedora counterparts.

Signed-off-by: Nils Philippsen <nils@redhat.com>